### PR TITLE
making the build killer kill waiting builds in addition to testing ones

### DIFF
--- a/lib/codeship_api/build.rb
+++ b/lib/codeship_api/build.rb
@@ -30,7 +30,7 @@ module CodeshipApi
     end
 
     def stop
-      CodeshipApi.client.post(uri + "/stop") if testing?
+      CodeshipApi.client.post(uri + "/stop") if waiting? || testing?
     end
   end
 end


### PR DESCRIPTION
Quick one to make the stop command stop a waiting build as well as a testing build.

Tested this in a console locally.